### PR TITLE
Run terraform fmt on the repository

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,21 +1,25 @@
 variable "cmd" {
   description = "The command used to create the resource."
 }
+
 variable "destroy_cmd" {
   description = "The command used to destroy the resource."
 }
+
 variable "account_id" {
   description = "The account that holds the role to assume in. Will use providers account by default"
-  default = "0"
+  default     = "0"
 }
+
 variable "role" {
   description = "The role to assume in order to run the cli command."
-  default = "0"
+  default     = "0"
 }
+
 variable "dependency_ids" {
   description = "IDs or ARNs of any resources that are a dependency of the resource created by this module."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 data "aws_caller_identity" "id" {}
@@ -49,5 +53,5 @@ resource "null_resource" "dependencies" {
 
 output "id" {
   description = "The ID of the null_resource used to provison the resource via cli. Useful for creating dependencies between cli resources"
-  value = "${null_resource.cli_resource.id}"
+  value       = "${null_resource.cli_resource.id}"
 }


### PR DESCRIPTION
Hello - submitting this as I'm using this repository as a submodule and have a linting build step to run `terraform fmt -check` however this fails the lint check, and ideally modules should use the canonical formatting.