### PR TITLE
Forcing evaluation to bash for `source` command to work

### DIFF
--- a/assume_role.sh
+++ b/assume_role.sh
@@ -22,4 +22,3 @@ export AWS_SECRET_ACCESS_KEY=$(echo "${aws_creds}" | grep SecretAccessKey | awk 
 export AWS_SESSION_TOKEN=$(echo "${aws_creds}" | grep SessionToken | awk -F'"' '{print $4}' )
 export AWS_SECURITY_TOKEN=$(echo "${aws_creds}" | grep SessionToken | awk -F'"' '{print $4}' )
 echo "session '$role_session_name' valid for 60 minutes"
-echo "aws creds obtained are: '$aws_creds'"

--- a/assume_role.sh
+++ b/assume_role.sh
@@ -22,3 +22,4 @@ export AWS_SECRET_ACCESS_KEY=$(echo "${aws_creds}" | grep SecretAccessKey | awk 
 export AWS_SESSION_TOKEN=$(echo "${aws_creds}" | grep SessionToken | awk -F'"' '{print $4}' )
 export AWS_SECURITY_TOKEN=$(echo "${aws_creds}" | grep SessionToken | awk -F'"' '{print $4}' )
 echo "session '$role_session_name' valid for 60 minutes"
+echo "aws creds obtained are: '$aws_creds'"

--- a/assume_role.sh
+++ b/assume_role.sh
@@ -1,8 +1,6 @@
-#!/bin/bash
-
 if [ "$#" -ne 2 ]
 then
-  echo "Usage: . assume_role.sh [account_id] [role]"
+  echo "Usage: source assume_role.sh [account_id] [role]"
   exit 1
 fi
 

--- a/assume_role.sh
+++ b/assume_role.sh
@@ -1,6 +1,6 @@
 if [ "$#" -ne 2 ]
 then
-  echo "Usage: source assume_role.sh [account_id] [role]"
+  echo "Usage: . assume_role.sh [account_id] [role]"
   exit 1
 fi
 

--- a/assume_role.sh
+++ b/assume_role.sh
@@ -9,7 +9,7 @@ fi
 ACCOUNT="$1"
 ROLE="$2"
 
-role_session_name=`cat /proc/sys/kernel/random/uuid || date | cksum | cut -d " " -f 1`
+role_session_name=`cat /proc/sys/kernel/random/uuid 2>/dev/null || date | cksum | cut -d " " -f 1`
 aws_creds=$(aws sts assume-role --role-arn arn:aws:iam::${ACCOUNT}:role/$ROLE --role-session-name $role_session_name --duration-seconds 3600 --output json)
 
 if [ "$?" -ne 0 ]

--- a/assume_role.sh
+++ b/assume_role.sh
@@ -9,7 +9,7 @@ fi
 ACCOUNT="$1"
 ROLE="$2"
 
-role_session_name=`uuidgen || date | cksum | cut -d " " -f 1`
+role_session_name=`cat /proc/sys/kernel/random/uuid || date | cksum | cut -d " " -f 1`
 aws_creds=$(aws sts assume-role --role-arn arn:aws:iam::${ACCOUNT}:role/$ROLE --role-session-name $role_session_name --duration-seconds 3600 --output json)
 
 if [ "$?" -ne 0 ]

--- a/assume_role.sh
+++ b/assume_role.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [ "$#" -ne 2 ]
 then
   echo "Usage: . assume_role.sh [account_id] [role]"

--- a/main.tf
+++ b/main.tf
@@ -26,18 +26,18 @@ data "aws_caller_identity" "id" {}
 
 locals {
   account_id      = "${var.account_id == 0 ? data.aws_caller_identity.id.account_id : var.account_id}"
-  assume_role_cmd = "/bin/bash -c 'source ${path.module}/assume_role.sh ${local.account_id} ${var.role}'"
+  assume_role_cmd = "source ${path.module}/assume_role.sh ${local.account_id} ${var.role}"
 }
 
 resource "null_resource" "cli_resource" {
   provisioner "local-exec" {
     when    = "create"
-    command = "${var.role == 0 ? "" : "${local.assume_role_cmd} && "}${var.cmd}"
+    command = "/bin/bash -c '${var.role == 0 ? "" : "${local.assume_role_cmd} && "}${var.cmd}'"
   }
 
   provisioner "local-exec" {
     when    = "destroy"
-    command = "${var.role == 0 ? "" : "${local.assume_role_cmd} && "}${var.destroy_cmd}"
+    command = "/bin/bash -c '${var.role == 0 ? "" : "${local.assume_role_cmd} && "}${var.destroy_cmd}'"
   }
 
   # By depending on the null_resource, the cli resource effectively depends on the existance

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ data "aws_caller_identity" "id" {}
 
 locals {
   account_id      = "${var.account_id == 0 ? data.aws_caller_identity.id.account_id : var.account_id}"
-  assume_role_cmd = "source ${path.module}/assume_role.sh ${local.account_id} ${var.role}"
+  assume_role_cmd = "/bin/bash -c 'source ${path.module}/assume_role.sh ${local.account_id} ${var.role}'"
 }
 
 resource "null_resource" "cli_resource" {

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ data "aws_caller_identity" "id" {}
 
 locals {
   account_id      = "${var.account_id == 0 ? data.aws_caller_identity.id.account_id : var.account_id}"
-  assume_role_cmd = ". ${path.module}/assume_role.sh ${local.account_id} ${var.role}"
+  assume_role_cmd = "source ${path.module}/assume_role.sh ${local.account_id} ${var.role}"
 }
 
 resource "null_resource" "cli_resource" {

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ data "aws_caller_identity" "id" {}
 
 locals {
   account_id      = "${var.account_id == 0 ? data.aws_caller_identity.id.account_id : var.account_id}"
-  assume_role_cmd = "source ${path.module}/assume_role.sh ${local.account_id} ${var.role}"
+  assume_role_cmd = ". ${path.module}/assume_role.sh ${local.account_id} ${var.role}"
 }
 
 resource "null_resource" "cli_resource" {


### PR DESCRIPTION
Submitted for your approval, we have a need for this functionality on our project to create cross-account authorization trust between VPC A and hosted zone B but since our build process is run through Jenkins with the default shell, running the `source` command on the script currently causes the build to fail.

This change will force the evaluation of the command to /bin/bash on any systems that provide the capability so that `source` will continue to work; switching to the posix-compatible `.` proved too difficult to pass arguments to the script.