### PR TITLE
Fix destroy cmd usage

### DIFF
--- a/assume_role.sh
+++ b/assume_role.sh
@@ -4,19 +4,20 @@ then
   exit 1
 fi
 
-ACCOUNT="$1"
-ROLE="$2"
+# ACCOUNT="$1"
+# ROLE="$2"
 
-role_session_name=`cat /proc/sys/kernel/random/uuid 2>/dev/null || date | cksum | cut -d " " -f 1`
-aws_creds=$(aws sts assume-role --role-arn arn:aws:iam::${ACCOUNT}:role/$ROLE --role-session-name $role_session_name --duration-seconds 3600 --output json)
+# role_session_name=`cat /proc/sys/kernel/random/uuid 2>/dev/null || date | cksum | cut -d " " -f 1`
+# aws_creds=$(aws sts assume-role --role-arn arn:aws:iam::${ACCOUNT}:role/$ROLE --role-session-name $role_session_name --duration-seconds 3600 --output json)
 
-if [ "$?" -ne 0 ]
-then
-  exit 1
-fi
+# if [ "$?" -ne 0 ]
+# then
+#   exit 1
+# fi
 
-export AWS_ACCESS_KEY_ID=$(echo "${aws_creds}" | grep AccessKeyId | awk -F'"' '{print $4}' )
-export AWS_SECRET_ACCESS_KEY=$(echo "${aws_creds}" | grep SecretAccessKey | awk -F'"' '{print $4}' )
-export AWS_SESSION_TOKEN=$(echo "${aws_creds}" | grep SessionToken | awk -F'"' '{print $4}' )
-export AWS_SECURITY_TOKEN=$(echo "${aws_creds}" | grep SessionToken | awk -F'"' '{print $4}' )
-echo "session '$role_session_name' valid for 60 minutes"
+# export AWS_ACCESS_KEY_ID=$(echo "${aws_creds}" | grep AccessKeyId | awk -F'"' '{print $4}' )
+# export AWS_SECRET_ACCESS_KEY=$(echo "${aws_creds}" | grep SecretAccessKey | awk -F'"' '{print $4}' )
+# export AWS_SESSION_TOKEN=$(echo "${aws_creds}" | grep SessionToken | awk -F'"' '{print $4}' )
+# export AWS_SECURITY_TOKEN=$(echo "${aws_creds}" | grep SessionToken | awk -F'"' '{print $4}' )
+# echo "session '$role_session_name' valid for 60 minutes"
+echo "Not needed"

--- a/assume_role.sh
+++ b/assume_role.sh
@@ -4,20 +4,19 @@ then
   exit 1
 fi
 
-# ACCOUNT="$1"
-# ROLE="$2"
+ACCOUNT="$1"
+ROLE="$2"
 
-# role_session_name=`cat /proc/sys/kernel/random/uuid 2>/dev/null || date | cksum | cut -d " " -f 1`
-# aws_creds=$(aws sts assume-role --role-arn arn:aws:iam::${ACCOUNT}:role/$ROLE --role-session-name $role_session_name --duration-seconds 3600 --output json)
+role_session_name=`cat /proc/sys/kernel/random/uuid 2>/dev/null || date | cksum | cut -d " " -f 1`
+aws_creds=$(aws sts assume-role --role-arn arn:aws:iam::${ACCOUNT}:role/$ROLE --role-session-name $role_session_name --duration-seconds 3600 --output json)
 
-# if [ "$?" -ne 0 ]
-# then
-#   exit 1
-# fi
+if [ "$?" -ne 0 ]
+then
+  exit 1
+fi
 
-# export AWS_ACCESS_KEY_ID=$(echo "${aws_creds}" | grep AccessKeyId | awk -F'"' '{print $4}' )
-# export AWS_SECRET_ACCESS_KEY=$(echo "${aws_creds}" | grep SecretAccessKey | awk -F'"' '{print $4}' )
-# export AWS_SESSION_TOKEN=$(echo "${aws_creds}" | grep SessionToken | awk -F'"' '{print $4}' )
-# export AWS_SECURITY_TOKEN=$(echo "${aws_creds}" | grep SessionToken | awk -F'"' '{print $4}' )
-# echo "session '$role_session_name' valid for 60 minutes"
-echo "Not needed"
+export AWS_ACCESS_KEY_ID=$(echo "${aws_creds}" | grep AccessKeyId | awk -F'"' '{print $4}' )
+export AWS_SECRET_ACCESS_KEY=$(echo "${aws_creds}" | grep SecretAccessKey | awk -F'"' '{print $4}' )
+export AWS_SESSION_TOKEN=$(echo "${aws_creds}" | grep SessionToken | awk -F'"' '{print $4}' )
+export AWS_SECURITY_TOKEN=$(echo "${aws_creds}" | grep SessionToken | awk -F'"' '{print $4}' )
+echo "session '$role_session_name' valid for 60 minutes"

--- a/main.tf
+++ b/main.tf
@@ -18,40 +18,48 @@ variable "role" {
 
 variable "dependency_ids" {
   description = "IDs or ARNs of any resources that are a dependency of the resource created by this module."
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 data "aws_caller_identity" "id" {}
 
 locals {
-  account_id      = "${var.account_id == 0 ? data.aws_caller_identity.id.account_id : var.account_id}"
+  account_id      = var.account_id == 0 ? data.aws_caller_identity.id.account_id : var.account_id
   assume_role_cmd = "source ${path.module}/assume_role.sh ${local.account_id} ${var.role}"
 }
 
 resource "null_resource" "cli_resource" {
+  triggers = {
+    role            = var.role
+    cmd             = var.cmd
+    destroy_cmd     = var.destroy_cmd
+    assume_role_cmd = local.assume_role_cmd
+  }
   provisioner "local-exec" {
     when    = "create"
-    command = "/bin/bash -c '${var.role == 0 ? "" : "${local.assume_role_cmd} && "}${var.cmd}'"
+    command = "/bin/bash -c '${self.triggers.role == 0 ? "" : "${self.triggers.assume_role_cmd} && "}${self.triggers.cmd}'"
   }
 
   provisioner "local-exec" {
     when    = "destroy"
-    command = "/bin/bash -c '${var.role == 0 ? "" : "${local.assume_role_cmd} && "}${var.destroy_cmd}'"
+    command = "/bin/bash -c '${self.triggers.role == 0 ? "" : "${self.triggers.assume_role_cmd} && "}${self.triggers.destroy_cmd}'"
   }
 
   # By depending on the null_resource, the cli resource effectively depends on the existance
   # of the resources identified by the ids provided via the dependency_ids list variable.
-  depends_on = ["null_resource.dependencies"]
+  depends_on = [
+    null_resource.dependencies
+  ]
 }
 
 resource "null_resource" "dependencies" {
   triggers = {
-    dependencies = "${join(",", var.dependency_ids)}"
+    dependencies = join(",", var.dependency_ids)
   }
 }
 
 output "id" {
   description = "The ID of the null_resource used to provison the resource via cli. Useful for creating dependencies between cli resources"
-  value       = "${null_resource.cli_resource.id}"
+  value       = null_resource.cli_resource.id
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     null = {
       source  = "hashicorp/null"
-      version ~> "3.1"
+      version = "~> 3.1"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version ~> "3.1"
+    }
+  }
+}


### PR DESCRIPTION
Terraform does not allow to use variables other than self, count and for_each in destroy command.
Also updated code to avoid deprecation warnings and fix variable types.